### PR TITLE
Added § to the keymap for people that have re-mapped it to #

### DIFF
--- a/keymaps/ruby-string-interpolation.cson
+++ b/keymaps/ruby-string-interpolation.cson
@@ -10,3 +10,4 @@
 '.editor':
   '#': 'ruby-string-interpolation:insert'
   'alt-3': 'ruby-string-interpolation:insert'
+  '§': 'ruby-string-interpolation:insert'


### PR DESCRIPTION
Added § to the keymap, for people with the Apple UK keyboard who have re-mapped it to # in favour of alt-3. See [here](http://grasuth.com/2010/11/03/remap-key-on-uk-keyboards/) for info on remapping.
