### PR TITLE
Changed keymapping context

### DIFF
--- a/keymaps/ruby-string-interpolation.cson
+++ b/keymaps/ruby-string-interpolation.cson
@@ -7,6 +7,6 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
-'.editor':
+'.editor:not(.mini)':
   '#': 'ruby-string-interpolation:insert'
   'alt-3': 'ruby-string-interpolation:insert'


### PR DESCRIPTION
Hi,

I"m using your nice package. Thank you!

Today, I got a error like this:

```
Uncaught TypeError: Object #<SettingsView> has no method 'getCursorScopes' 
```

The error occurred when type "#" at Setting Pane that is also ".editor" context.
We do now want to insert interpolation at setting pane, command palette and so on.

Then I changed keybinding context.

``` diff
- Before: '.editor:not':
+ After:  '.editor:not(.mini)':
```

How about this?

Thanks,
